### PR TITLE
Update build.config.rpi5

### DIFF
--- a/build.config.rpi5
+++ b/build.config.rpi5
@@ -12,5 +12,5 @@ dtbs
 
 FILES="
 arch/arm64/boot/Image
-arch/arm64/boot/dts/broadcom/bcm2711-rpi-5-b.dtb
+arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dtb
 "


### PR DESCRIPTION
There is bcm2712-rpi-5-b.dts no bcm2711-rpi-5-b.dts in  arch/arm/boot/dts 
same in arch/arm64/boot/dts/broadcom/
bcm2712-rpi-5-b.dts which includes 
"../../../../arm/boot/dts/bcm2712-rpi-5-b.dts"