### PR TITLE
Consider enabling USB printer support

### DIFF
--- a/arch/arm64/configs/android_rpi4_defconfig
+++ b/arch/arm64/configs/android_rpi4_defconfig
@@ -4860,7 +4860,7 @@ CONFIG_USB_DWCOTG=y
 # USB Device Class drivers
 #
 CONFIG_USB_ACM=y
-# CONFIG_USB_PRINTER is not set
+CONFIG_USB_PRINTER=y
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set
 

--- a/arch/arm64/configs/android_rpi5_defconfig
+++ b/arch/arm64/configs/android_rpi5_defconfig
@@ -4869,7 +4869,7 @@ CONFIG_USB_DWCOTG=y
 # USB Device Class drivers
 #
 CONFIG_USB_ACM=y
-# CONFIG_USB_PRINTER is not set
+CONFIG_USB_PRINTER=y
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set
 


### PR DESCRIPTION
My usecase is that I have an old USB-only printer near my TV, so I thought would it be possible to connect them together? 

It looks like it's more or less possible. Steps that I did:
- Recompile & install the new kernel with CONFIG_USB_PRINTER=y;
- Wrap & compile p910nd with NDK (here's my `Android.mk`):
```
LOCAL_PATH := $(call my-dir)
include $(CLEAR_VARS)

$(call import-add-path,$(LOCAL_PATH))

LOCAL_MODULE    := p910nd
LOCAL_CFLAGS    := -DLOCKFILE_DIR=\"/data/p910nd/lock\"
LOCAL_SRC_FILES := p910nd/p910nd.c

include $(BUILD_EXECUTABLE)
```
- Push it to the target and run:
```
mknod /dev/lp0 c 180 0
mkdir -p /data/p910nd/lock
./p910nd -d
```
- After that I was able to print (follow p910nd guide on how to configure such printer in Linux).

Since the RPI is always on and has good connectivity it makes it a good candidate for a print server. Some further testing has to be done (I'm not sure how p910nd reacts to network disconnections and how robust it is in general). Plus it runs with root and SELinux is off so it makes it a potential attack vector.  

While I'm on it, I thought would it be possible to include this CONFIG_USB_PRINTER option upstream? The difference in kernel size is only about 60kb so hopefully it does not create a concern.

This PR adds such option to 14.0 for both Rpi 4 and 5 (edited manually despite the warning, though I'm curious why you keep the entire autogenerated config rather than the diff produced by savedefconfig?)