### PR TITLE
Update BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1814,6 +1814,7 @@ kernel_build(
     ],
     arch = "arm64",
     build_config = "build.config.rpi",
+    check_defconfig = "disabled",
     defconfig = "arch/arm64/configs/android_rpi4_defconfig",
     make_goals = [
          "Image",


### PR DESCRIPTION
[RPI4][ Bazel Kernel] Fix kernel config mismatching for Clang.

While trying to re-build the kernel, clang config error happened. 

"ERROR: CONFIG_CC_VERSION_TEXT: actual 'Android (14043575, +pgo, +bolt, +lto, +mlgo, based on r536225) clang version 19.0.1 (https://android.googlesource.com/toolchain/llvm-project b3a530ec6537146650e42be89f1089e9a3588460)', expected 'Android (12833971, +pgo, +bolt, +lto, +mlgo, based on r536225) clang version 19.0.1 (https://android.googlesource.com/toolchain/llvm-project b3a530ec6537146650e42be89f1089e9a3588460)' from common/arch/arm64/configs/android_rpi4_defconfig" 

This change allow the re-building by ignoring the main error, more systematic solution might be needed.